### PR TITLE
Update normalize.css version displayed

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -77,7 +77,7 @@
 
                     <div class="grid-cell">
                         <h3><span class="star">&#x2605;</span> Normalize.css and helpers</h3>
-                        <p>Includes <a href="https://necolas.github.io/normalize.css/">Normalize.css</a> v2 &mdash; a modern, HTML5-ready alternative to CSS resets &mdash; and further base styles, utilities, and media queries.</p>
+                        <p>Includes <a href="https://necolas.github.io/normalize.css/">Normalize.css</a> v3 &mdash; a modern, HTML5-ready alternative to CSS resets &mdash; and further base styles, utilities, and media queries.</p>
                     </div>
 
                     <div class="grid-cell">


### PR DESCRIPTION
The `index.html` page has still an old `normalize.css` version number in it.
